### PR TITLE
add whatsnew and test coverage

### DIFF
--- a/docs/src/whatsnew/latest.rst
+++ b/docs/src/whatsnew/latest.rst
@@ -25,7 +25,7 @@ This document explains the changes made to Iris for this release
 📢 Announcements
 ================
 
-#. N/A
+#. Welcome to `@krikru`_ who made their first contribution to Iris 🎉
 
 
 ✨ Features
@@ -131,6 +131,11 @@ This document explains the changes made to Iris for this release
 #. `@rcomer`_ modified cube arithmetic to handle mismatches in the cube's data
    array type.  This prevents masks being lost in some cases and therefore
    resolves :issue:`2987`.  (:pull:`3790`)
+
+#. `@krikru`_ and `@rcomer`_ updated :mod:`iris.quickplot` such that the
+   colorbar is added to the correct ``axes`` when specified as a keyword
+   argument to a plotting routine. Otherwise, by default the colorbar will be
+   added to the current axes of the current figure. (:pull:`4894`)
 
 
 💣 Incompatible Changes
@@ -272,6 +277,7 @@ This document explains the changes made to Iris for this release
     core dev names are automatically included by the common_links.inc:
 
 .. _@evertrol: https://github.com/evertrol
+.. _@krikru: https://github.com/krikru
 
 
 .. comment

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -254,27 +254,26 @@ class TestSubplotColorbar(tests.IrisTest):
         theta = _load_theta()
         coords = ["model_level_number", "grid_longitude"]
         self.data = next(theta.slices(coords))
+        spec = (1, 1, 1)
+        self.fig1 = plt.figure()
+        self.ax1 = self.fig1.add_subplot(*spec)
+        self.fig2 = plt.figure()
+        self.ax2 = self.fig2.add_subplot(*spec)
 
-    @staticmethod
-    def _plot():
-        fig1 = plt.figure()
-        ax1 = fig1.add_subplot(1, 1, 1)
-        fig2 = plt.figure()
-        _ = fig2.add_subplot(1, 1, 1)
-
-        return fig1, ax1, fig2
+    def _check(self, mappable, fig, ax):
+        self.assertIs(mappable.axes, ax)
+        self.assertIs(mappable.colorbar.mappable, mappable)
+        self.assertIs(mappable.colorbar.ax.get_figure(), fig)
 
     def test__with_axes(self):
-        fig1, ax1, _ = self._plot()
         # plot using the first figure subplot axes
-        gcs = qplt.contourf(self.data, axes=ax1)
-        self.assertIs(gcs.colorbar.ax.get_figure(), fig1)
+        mappable = qplt.contourf(self.data, axes=self.ax1)
+        self._check(mappable, self.fig1, self.ax1)
 
     def test__without_axes(self):
-        _, _, fig2 = self._plot()
         # plot using the second/last figure subplot axes (default)
-        gcs = qplt.contourf(self.data)
-        self.assertIs(gcs.colorbar.ax.get_figure(), fig2)
+        mappable = qplt.contourf(self.data)
+        self._check(mappable, self.fig2, self.ax2)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -255,25 +255,30 @@ class TestSubplotColorbar(tests.IrisTest):
         coords = ["model_level_number", "grid_longitude"]
         self.data = next(theta.slices(coords))
         spec = (1, 1, 1)
-        self.fig1 = plt.figure()
-        self.ax1 = self.fig1.add_subplot(*spec)
-        self.fig2 = plt.figure()
-        self.ax2 = self.fig2.add_subplot(*spec)
+        self.figure1 = plt.figure()
+        self.axes1 = self.figure1.add_subplot(*spec)
+        self.figure2 = plt.figure()
+        self.axes2 = self.figure2.add_subplot(*spec)
 
-    def _check(self, mappable, fig, ax):
-        self.assertIs(mappable.axes, ax)
+    def _check(self, mappable, figure, axes):
+        self.assertIs(mappable.axes, axes)
         self.assertIs(mappable.colorbar.mappable, mappable)
-        self.assertIs(mappable.colorbar.ax.get_figure(), fig)
+        self.assertIs(mappable.colorbar.ax.get_figure(), figure)
 
-    def test__with_axes(self):
-        # plot using the first figure subplot axes
-        mappable = qplt.contourf(self.data, axes=self.ax1)
-        self._check(mappable, self.fig1, self.ax1)
+    def test_with_axes1(self):
+        # plot using the first figure subplot axes (explicit)
+        mappable = qplt.contourf(self.data, axes=self.axes1)
+        self._check(mappable, self.figure1, self.axes1)
 
-    def test__without_axes(self):
+    def test_with_axes2(self):
+        # plot using the second figure subplot axes (explicit)
+        mappable = qplt.contourf(self.data, axes=self.axes2)
+        self._check(mappable, self.figure2, self.axes2)
+
+    def test_without_axes__default(self):
         # plot using the second/last figure subplot axes (default)
         mappable = qplt.contourf(self.data)
-        self._check(mappable, self.fig2, self.ax2)
+        self._check(mappable, self.figure2, self.axes2)
 
 
 if __name__ == "__main__":

--- a/lib/iris/tests/test_quickplot.py
+++ b/lib/iris/tests/test_quickplot.py
@@ -247,5 +247,35 @@ class TestTimeReferenceUnitsLabels(tests.GraphicsTest):
         self.check_graphic()
 
 
+@tests.skip_data
+@tests.skip_plot
+class TestSubplotColorbar(tests.IrisTest):
+    def setUp(self):
+        theta = _load_theta()
+        coords = ["model_level_number", "grid_longitude"]
+        self.data = next(theta.slices(coords))
+
+    @staticmethod
+    def _plot():
+        fig1 = plt.figure()
+        ax1 = fig1.add_subplot(1, 1, 1)
+        fig2 = plt.figure()
+        _ = fig2.add_subplot(1, 1, 1)
+
+        return fig1, ax1, fig2
+
+    def test__with_axes(self):
+        fig1, ax1, _ = self._plot()
+        # plot using the first figure subplot axes
+        gcs = qplt.contourf(self.data, axes=ax1)
+        self.assertIs(gcs.colorbar.ax.get_figure(), fig1)
+
+    def test__without_axes(self):
+        _, _, fig2 = self._plot()
+        # plot using the second/last figure subplot axes (default)
+        gcs = qplt.contourf(self.data)
+        self.assertIs(gcs.colorbar.ax.get_figure(), fig2)
+
+
 if __name__ == "__main__":
     tests.main()


### PR DESCRIPTION
## 🚀 Pull Request

### Description
Hey @krikru,

As promised, here's some updates that's targeting your `patch-1` branch, which is the source of the pull-request https://github.com/SciTools/iris/pull/4894.

It basically adds a suitable entry to our documentation `whatsnew`, plus we blow the trumpet that it's your first contribution to `iris` :smile: 

I've also added a couple of tests to exercise the change in behaviour, which is based on a pull-request (now closed and unmerged) by @rcomer, see https://github.com/SciTools/iris/pull/4136.

To be transparent and fair, I've also acknowledged @rcomer's contribution in the `whatsnew` along side yourself.

Here is proof that the [ci-tests](https://github.com/bjlittle/iris/actions/runs/2826229475) are passing for this change from my fork of `iris`.

If you're happy with my suggestions, then simply merge this pull-request, and it will automatically become part of your associated pull-request on `iris`.

At that point, I think we're good to bank this goodness in time for the `iris` 3.3 release :+1: 

---
[Consult Iris pull request check list]( https://scitools-iris.readthedocs.io/en/latest/developers_guide/contributing_pull_request_checklist.html)
